### PR TITLE
Update Scanpyplus.py

### DIFF
--- a/Scanpyplus.py
+++ b/Scanpyplus.py
@@ -408,7 +408,7 @@ def celltype_per_stage_plot(adata,celltypekey='louvain',stagekey='batch',plotlab
         plt.barh(stagelist[::-1],count_ratio_array[i,::-1],
             left=np.sum(count_ratio_array[0:i,::-1],axis=0),color=colors[celltypelist[i]],label=celltypelist[i])
         plt.yticks(fontsize=yfontsize)
-    plt.grid(b=False)
+    plt.grid(visible=False)
     if plotlabel:
         plt.legend(celltypelist,fontsize=fontsize,bbox_to_anchor=legend_pos)
     if savefig is not None:
@@ -433,7 +433,7 @@ def stage_per_celltype_plot(adata,celltypekey='louvain',stagekey='batch',plotlab
             bottom=1-np.sum(count_ratio_array[0:i+1,:],axis=0),
            color=colors[stagelist[i]],label=stagelist[i])
         plt.xticks(fontsize=xfontsize)
-    plt.grid(b=False)
+    plt.grid(visible=False)
     plt.legend(stagelist,fontsize=fontsize,bbox_to_anchor=legend_pos)
     plt.xticks(rotation=90)
     if savefig is not None:


### PR DESCRIPTION
Matplotlib deprecation: replace grid(b=False) with grid(visible=False) to fix b parameter deprecation in the matplotlib grid call

Best regards,
Yuefei