### PR TITLE
Contribute new functions

### DIFF
--- a/Scanpyplus.py
+++ b/Scanpyplus.py
@@ -1513,6 +1513,27 @@ def OverlapBarcode(adatas, samplename):
         'overlap_percentage': overlap_matrix.div(overlap_matrix.sum(axis=1), axis=0) * 100
     }
 
+def CheckDuplicate(adata, batch_key='sample', size_height=3, showplot=True):
+    #Detect barcodes shared across samples/batches within a single concatenated AnnData
+    #object. Splits adata by batch_key, reuses OverlapBarcode for pairwise overlap counts,
+    #and plots the overlap as an UpSet plot via UpSetFromLists.
+    from pandasPlus import UpSetFromLists
+
+    if batch_key not in adata.obs.columns:
+        raise ValueError(f"Column '{batch_key}' not found in adata.obs")
+
+    samplename = adata.obs[batch_key].astype(str).unique().tolist()
+    adatas = [adata[adata.obs[batch_key].astype(str) == s] for s in samplename]
+
+    overlap = OverlapBarcode(adatas, samplename)
+    overlap['upset'] = UpSetFromLists(
+        listOflist=[overlap['barcode_dict'][s].tolist() for s in samplename],
+        labels=samplename,
+        size_height=size_height,
+        showplot=showplot
+    )
+    return overlap
+
 def show_graph_with_labels(adjacency_matrix, threshold=0.9):
     #Display network graph from adjacency matrix
     import networkx as nx

--- a/Scanpyplus.py
+++ b/Scanpyplus.py
@@ -981,6 +981,65 @@ def DeepTree_per_batch(adata,batch_key='batch',obslist=['batch'],min_clustersize
     adata.var['Deep_n']=temp
     return adata
 
+def _DeepTree_process_batch(bdata,key,obslist,Cutoff,CladeSize,threads_per_worker,save_dir=None):
+    #Runs in a joblib worker process: cap BLAS threads before any heavy
+    #numpy/scipy call in this process, and force a headless mpl backend
+    #before touching pyplot (no display in a worker process).
+    os.environ['OMP_NUM_THREADS']=str(threads_per_worker)
+    os.environ['OPENBLAS_NUM_THREADS']=str(threads_per_worker)
+    os.environ['MKL_NUM_THREADS']=str(threads_per_worker)
+    os.environ['NUMEXPR_NUM_THREADS']=str(threads_per_worker)
+    import matplotlib
+    matplotlib.use('Agg')
+    sc.pp.filter_genes(bdata,min_cells=3)
+    sc.pl.umap(bdata,color=obslist,show=False)
+    cellnames=bdata.obs_names.tolist()
+    genenames=bdata.var_names.tolist()
+    bdata2,test,test1,test2=DeepTree(bdata,
+                    MouseC1ColorDict2={False:'#000000',True:'#00FFFF'},
+                    cell_type=obslist,cellnames=cellnames,genenames=genenames,
+                    row_cluster=True,col_cluster=True,Cutoff=Cutoff,CladeSize=CladeSize)
+    deep_genes=bdata2[:,bdata2.var['Deep']].var_names.tolist()
+    if save_dir is not None:
+        #test1/test2 are already fully rendered by DeepTree() above; saving
+        #them is just a PNG encode+write, not a re-run of the clustering.
+        #test (the plain HVG heatmap used only to derive Deep) isn't saved.
+        test1.savefig(os.path.join(save_dir,f'{key}_deeptree_deepmarked.png'),dpi=150,bbox_inches='tight')
+        test2.savefig(os.path.join(save_dir,f'{key}_deeptree_deepselected.png'),dpi=150,bbox_inches='tight')
+    plt.close('all')
+    return key,deep_genes
+
+def DeepTree_per_batch_parallel(adata,batch_key='batch',obslist=['batch'],min_clustersize=100,Cutoff=0.8,CladeSize=2,n_jobs=9,threads_per_worker=3,save_dir=None):
+    #Parallel version of DeepTree_per_batch: identical algorithm and output
+    #(Deep_<batch> / Deep_n columns), but the independent per-batch DeepTree()
+    #calls run concurrently via joblib instead of a serial for-loop.
+    #Keep n_jobs*threads_per_worker within your machine's shared-usage budget
+    #(e.g. n_jobs=9, threads_per_worker=3 -> 27 cores).
+    #save_dir: if given, each batch's Deep-marked and Deep-selected heatmaps
+    #are written there as PNGs (workers run headless, so nothing displays
+    #inline even in a notebook -- pass save_dir to inspect them afterward).
+    batchlist=adata.obs[batch_key].value_counts()
+    keys=batchlist[batchlist>min_clustersize].index.tolist()
+    if save_dir is not None:
+        os.makedirs(save_dir,exist_ok=True)
+    #Slice each batch's subset up front in the calling process (cheap) so
+    #workers only pickle the small per-batch subset, not the full adata.
+    batch_subsets={}
+    for key in keys:
+        bdata=adata[:,adata.var['highly_variable_'+key]][adata.obs[batch_key]==key,:].copy()
+        batch_subsets[key]=bdata
+    results=joblib.Parallel(n_jobs=n_jobs)(
+        joblib.delayed(_DeepTree_process_batch)(batch_subsets[key],key,obslist,Cutoff,CladeSize,threads_per_worker,save_dir)
+        for key in keys)
+    for key,deep_genes in results:
+        adata.var['Deep_'+key]=pd.Series(adata.var_names,index=adata.var_names).isin(deep_genes)
+    adata.var['Deep_n']=0
+    temp=adata.var['Deep_n'].astype('int32')
+    for key in keys:
+        temp=temp+adata.var['Deep_'+key].astype('int32')
+    adata.var['Deep_n']=temp
+    return adata
+
 def HVG_Venn_Upset(adata,genelists,size_height=3):
     from upsetplot import UpSet
     from upsetplot import plot

--- a/Scanpyplus.py
+++ b/Scanpyplus.py
@@ -1344,6 +1344,121 @@ def QC(adata, species="human", mt_prefix=None,
     sc.pp.calculate_qc_metrics(
         adata, qc_vars=["mt", "ribo", "hb"], log1p=log1p,inplace=inplace)
 
+sc_genes = ['EEF1A1', 'TPT1', 'FTH1', 'FTL', 'SERF2', 'ATP5F1E', 'GAPDH', 'UBA52', 'COX7C', 'MIF']
+sn_genes = ['FTX', 'AGAP1', 'GMDS-DT', 'PARD3', 'WWOX', 'MAGI2', 'PKHD1', 'NHS', 'AC098829.1', 'DPP6']
+
+def CellorNuc(
+    adata,
+    sc_genes,
+    sn_genes,
+    cell_type_col='cell_type',
+    assay_col='assay',
+    sc_label='sc',
+    sn_label='sn',
+    clip_percentiles=(0.01, 0.99),
+    sc_threshold_percentile=0.05,
+    sn_threshold_percentile=0.95,
+    copy=False
+):
+    """
+    Scores single cells and single nuclei based on distinct gene signatures and
+    classifies anomalous cross-modality profiles.
+
+    Parameters
+    ----------
+    adata : AnnData
+        The annotated data matrix of shape n_obs × n_vars.
+    sc_genes : list
+        List of genes enriched in single-cell assays (e.g., cytoplasmic markers).
+    sn_genes : list
+        List of genes enriched in single-nucleus assays (e.g., nuclear markers).
+    cell_type_col : str, optional (default: 'cell_type')
+        Column in adata.obs containing cell type annotations.
+    assay_col : str, optional (default: 'assay')
+        Column in adata.obs containing the modality assay labels.
+    sc_label : str, optional (default: 'sc')
+        The exact string in assay_col identifying single-cell droplets.
+    sn_label : str, optional (default: 'sn')
+        The exact string in assay_col identifying single-nucleus droplets.
+    clip_percentiles : tuple, optional (default: (0.01, 0.99))
+        Percentiles used to clip (Winsorize) the differential score to prevent outliers.
+    sc_threshold_percentile : float, optional (default: 0.05)
+        The lower-bound percentile for typical SC profiles. Droplets falling below this
+        but above the SN upper bound become 'Uncertain'.
+    sn_threshold_percentile : float, optional (default: 0.95)
+        The upper-bound percentile for typical SN profiles. Droplets exceeding this
+        but falling below the SC lower bound become 'Uncertain'.
+    copy : bool, optional (default: False)
+        If True, returns a copy of the AnnData object. Otherwise, modifies in place.
+
+    Returns
+    -------
+    AnnData (if copy=True)
+        Updates adata.obs with score columns and 'modality_classification'.
+    """
+
+    adata = adata.copy() if copy else adata
+
+    # 1. Validate inputs
+    if cell_type_col not in adata.obs.columns:
+        raise ValueError(f"Column '{cell_type_col}' not found in adata.obs")
+    if assay_col not in adata.obs.columns:
+        raise ValueError(f"Column '{assay_col}' not found in adata.obs")
+
+    # 2. Filter for genes actually present in the matrix
+    sc_found = [g for g in sc_genes if g in adata.var_names]
+    sn_found = [g for g in sn_genes if g in adata.var_names]
+
+    if not sc_found or not sn_found:
+        raise ValueError("One or both gene lists have zero overlap with adata.var_names")
+
+    # 3. Score genes globally
+    sc.tl.score_genes(adata, gene_list=sc_found, score_name='sc_score')
+    sc.tl.score_genes(adata, gene_list=sn_found, score_name='sn_score')
+
+    # 4. Calculate differential score and clip outliers
+    adata.obs['cell_vs_nucleus_score'] = adata.obs['sc_score'] - adata.obs['sn_score']
+
+    vmin, vmax = adata.obs['cell_vs_nucleus_score'].quantile(list(clip_percentiles))
+    adata.obs['cell_vs_nucleus_score_clipped'] = adata.obs['cell_vs_nucleus_score'].clip(vmin, vmax)
+
+    # 5. Initialize classification column
+    adata.obs['modality_classification'] = 'Uncertain'
+
+    # 6. Apply cell-type specific statistical boundaries
+    for ct in adata.obs[cell_type_col].unique():
+        ct_mask = adata.obs[cell_type_col] == ct
+        sc_mask = ct_mask & (adata.obs[assay_col] == sc_label)
+        sn_mask = ct_mask & (adata.obs[assay_col] == sn_label)
+
+        # Determine SC lower bound using the parameterized percentile (min 0)
+        if sc_mask.any():
+            sc_lower = max(0.0, adata.obs.loc[sc_mask, 'cell_vs_nucleus_score'].quantile(sc_threshold_percentile))
+        else:
+            sc_lower = 0.0
+
+        # Determine SN upper bound using the parameterized percentile (max 0)
+        if sn_mask.any():
+            sn_upper = min(0.0, adata.obs.loc[sn_mask, 'cell_vs_nucleus_score'].quantile(sn_threshold_percentile))
+        else:
+            sn_upper = 0.0
+
+        # Classify Single-Cell droplets
+        if sc_mask.any():
+            adata.obs.loc[sc_mask & (adata.obs['cell_vs_nucleus_score'] >= sc_lower), 'modality_classification'] = 'Typical Cell (SC)'
+            adata.obs.loc[sc_mask & (adata.obs['cell_vs_nucleus_score'] <= sn_upper), 'modality_classification'] = 'Nucleus-like Cell (SC)'
+
+        # Classify Single-Nucleus droplets
+        if sn_mask.any():
+            adata.obs.loc[sn_mask & (adata.obs['cell_vs_nucleus_score'] <= sn_upper), 'modality_classification'] = 'Typical Nucleus (SN)'
+            adata.obs.loc[sn_mask & (adata.obs['cell_vs_nucleus_score'] >= sc_lower), 'modality_classification'] = 'Cell-like Nucleus (SN)'
+
+    # Convert to categorical for better memory efficiency and downstream plotting
+    categories = ['Typical Cell', 'Nucleus-like Cell', 'Typical Nucleus', 'Cell-like Nucleus', 'Uncertain']
+    adata.obs['modality_classification'] = pd.Categorical(adata.obs['modality_classification'], categories=categories)
+
+    return adata if copy else None
+
 def MapCategories(adata, key, corrections_dict):
 # Mapping old categories to new names based on corrections_dict and the adata.obs['key'] column. Column needs to be category. Also, adds new categories to category's keys. Requires a mapping dictionary.
  

--- a/Scanpyplus.py
+++ b/Scanpyplus.py
@@ -577,24 +577,40 @@ min_in_group_fraction=0.25,use_raw=False,method='wilcoxon'):
     Markers=pd.DataFrame(adata.uns['rank_genes_groups_filtered']['names'])
     return Markers.apply(lambda x: pd.Series(x.dropna().values))
 
-def HVGbyBatch(adata,batch_key='batch',min_mean=0.0125, max_mean=3, min_disp=0.5,\
-min_clustersize=100,genenames=['default']):
+def HVGbyBatch(adata,batch_key='batch',min_mean=0.0125,max_mean=3, min_disp=0.5,min_clustersize=100,genenames=['default'],flavor='seurat',n_top_genes=4000):
+    """
+    Identify highly variable genes per batch and count how many batches each gene is hvg in.
+
+    New Parameters:
+    - flavor: str
+        'seurat' or 'seurat_v3'
+    - n_top_genes: int
+        For seurat_v3 only,number of top genes to identify
+    """
     if 'default' in genenames:
         genenames = adata.var_names
+    
+    if flavor == 'seurat_v3' and 'counts' not in adata.layers:
+        raise ValueError("seurat_v3 flavor requires a 'counts' layer")
+
     sc.settings.verbosity=0
     batchlist=adata.obs[batch_key].value_counts()
-    for key in batchlist[batchlist>min_clustersize].index:
-        adata_sample = adata[adata.obs[batch_key]==key,:][:,genenames]
+    valid_batches = batchlist[batchlist>min_clustersize].index
+
+    for key in valid_batches:
+        adata_sample = adata[adata.obs[batch_key]==key,:][:,genenames].copy()
         print(key)
-        sc.pp.highly_variable_genes(adata_sample, min_mean=min_mean, max_mean=max_mean, min_disp=min_disp)
-        adata.var['highly_variable'+'_'+key]=pd.Series(adata.var_names,\
+        if flavor == 'seurat_v3':
+            sc.pp.highly_variable_genes(adata_sample, n_top_genes=n_top_genes, flavor='seurat_v3', layer='counts')
+        else:
+            sc.pp.highly_variable_genes(adata_sample, min_mean=min_mean, max_mean=max_mean, min_disp=min_disp)
+        adata.var[f'highly_variable_{key}']=pd.Series(adata.var_names,\
             index=adata.var_names).isin(adata_sample.var_names[adata_sample.var['highly_variable']])
+
     sc.settings.verbosity=3
-    adata.var['highly_variable_n']=0
-    temp=adata.var['highly_variable_n'].astype('int32')
-    for key in batchlist[batchlist>min_clustersize].index:
-        temp=temp+adata.var['highly_variable_'+key].astype('int32')
-    adata.var['highly_variable_n']=temp
+    hvg_cols = [f'highly_variable_{key}' for key in valid_batches]
+    adata.var['highly_variable_n'] = adata.var[hvg_cols].sum(axis=1).astype('int32')
+    
     return adata
 
 def HVG_cutoff(adata,range_int=10,cutoff=5000,HVG_var='highly_variable_n',fig_size=(8,6)):

--- a/Scanpyplus.py
+++ b/Scanpyplus.py
@@ -859,22 +859,28 @@ def PseudoBulk(adata, group_key, layer=None, gene_symbols=None):
         out[group] = np.ravel(X.mean(axis=0, dtype=np.float64))
     return out
 
-def Dotplot2D(adata,obs1,obs2,gene,cmap='OrRd', min_count=1):
+def Dotplot2D(adata,obs1,obs2,gene,cmap='OrRd', min_count=1, dot_max=1, dot_min=0, smallest_dot=10, largest_dot=100, size_exponent=0.5):
     #This function was modified from K Polanski's codes. It can plot a gene such as XIST across samples and cell types
     #require at least these many cells in a batch+celltype intersection to process it
 
     #extract a simpler form of all the needed data - the gene's expression and the two obs columns
     #this way things run way quicker downstream
-    expression = np.array(adata[:,gene].X)
+    X = adata[:, gene].X
+    if sparse.issparse(X):
+        expression = X.toarray().ravel()
+    else:
+        expression = np.asarray(X).ravel()
     batches = adata.obs[obs1].values
     celltypes = adata.obs[obs2].values
 
-    dot_size_df = pd.DataFrame(0.0, index=np.unique(batches), columns=np.unique(celltypes))
-    dot_color_df = pd.DataFrame(0.0, index=np.unique(batches), columns=np.unique(celltypes))
+    batch_levels = list(adata.obs[obs1].cat.categories) if pd.api.types.is_categorical_dtype(adata.obs[obs1]) else list(pd.Index(adata.obs[obs1].dropna()).unique())
+    celltype_levels = list(adata.obs[obs2].cat.categories) if pd.api.types.is_categorical_dtype(adata.obs[obs2]) else list(pd.Index(adata.obs[obs2].dropna()).unique())
+    dot_size_df = pd.DataFrame(0.0, index=batch_levels, columns=celltype_levels)
+    dot_color_df = pd.DataFrame(0.0, index=batch_levels, columns=celltype_levels)
 
-    for batch in np.unique(batches):
+    for batch in batch_levels:
         mask_batch = (batches == batch)
-        for celltype in np.unique(celltypes):
+        for celltype in celltype_levels:
             mask_celltype = (celltypes == celltype)
             #skip if there's not enough data for spot
             if np.sum(mask_batch & mask_celltype) >= min_count:
@@ -898,8 +904,15 @@ def Dotplot2D(adata,obs1,obs2,gene,cmap='OrRd', min_count=1):
     bdata.obs_names = list(dot_size_df.index)
     bdata.obs[obs1] = dot_size_df.index
     bdp = DotPlot(bdata, dot_size_df.columns, obs1, dot_size_df=dot_size_df, dot_color_df=dot_color_df)
-    bdp = bdp.style(cmap=cmap)
+    bdp = bdp.style(
+        cmap=cmap,
+        dot_max=dot_max,
+        dot_min=dot_min,
+        smallest_dot=smallest_dot,
+        largest_dot=largest_dot,
+        size_exponent=size_exponent)
     bdp.make_figure()
+    return bdp
 
 
 def DeepTree(adata,MouseC1ColorDict2,cell_type='louvain',gene_type='highly_variable',\


### PR DESCRIPTION
- **HVGbyBatch**: add `flavor='seurat_v3'` support (via `n_top_genes` + a `counts` layer) alongside the existing `seurat` flavor; per-batch HVG columns now aggregated with a vectorized sum instead of a Python loop.
- **Dotplot2D**: handle sparse `.X`, preserve the categorical level order of `obs1`/`obs2` instead of relying on `np.unique` sorting, expose `dot_max`/`dot_min`/`smallest_dot`/`largest_dot`/`size_exponent` passthrough to `DotPlot.style`, and return the `DotPlot` object instead of `None`.
- **DeepTree_per_batch_parallel** (new): joblib-parallel version of `DeepTree_per_batch` - runs the independent per-batch `DeepTree()` calls concurrently instead of in a serial loop; same output columns (`Deep_<batch>`, `Deep_n`).
- **CellorNuc** (new): scores each cell against paired single-cell vs. single-nucleus marker gene sets (`sc.tl.score_genes`) and flags droplets whose profile looks like the "wrong" modality for their assay/cell type - useful QC for mixed sc/sn datasets.
- **CheckDuplicate** (new): detects barcodes shared across samples/batches within a single concatenated AnnData. Wraps the existing `OverlapBarcode` for the pairwise overlap stats and `UpSetFromLists` for the visualization, so this is just `Scanpyplus.CheckDuplicate(adata, batch_key='sample')` instead of hand-rolling the barcode-list-per-sample boilerplate each time (requested after a Slack discussion on reproducing an UpSet plot for duplicate-sample detection).